### PR TITLE
Fix gunicorn memleak

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -114,7 +114,7 @@ def media_post_save(sender, instance, created, **kwargs):
                         f'set but is already marked to be skipped')
             else:            
                 if max_cap_age and filter_text:
-                    if (published > max_cap_age) and (source.is_regex_match(instance.title)):
+                    if (published > max_cap_age) and (instance.source.is_regex_match(instance.title)):
                         # Media was published after the cap date and matches the filter text, but is set to be skipped
                         print('Has a valid publishing date and matches filter, marking unskipped')
                         instance.skip = False
@@ -131,7 +131,7 @@ def media_post_save(sender, instance, created, **kwargs):
                         instance.skip = False
                         cap_changed = True
                 elif filter_text:
-                    if source.is_regex_match(instance.title):
+                    if instance.source.is_regex_match(instance.title):
                         # Media matches the filter text but is set to be skipped
                         log.info(f'Media: {instance.source} / {instance} matches the filter text, marking to be unskipped')
                         instance.skip = False
@@ -149,7 +149,7 @@ def media_post_save(sender, instance, created, **kwargs):
                         instance.skip = True
                         cap_changed = True
                 if filter_text:
-                    if not re.search(filter_text,instance.title):
+                    if not instance.source.is_regex_match(instance.title):
                         #media doesn't match the filter text but is not marked to be skipped
                         log.info(f'Media: {instance.source} / {instance} does not match the filter text')
                         instance.skip = True

--- a/tubesync/tubesync/gunicorn.py
+++ b/tubesync/tubesync/gunicorn.py
@@ -22,7 +22,9 @@ def get_bind():
 
 
 workers = get_num_workers()
-timeout = 30
+timeout = 600
+max_requests = 100
+max_requests_jitter = 10
 chdir = '/app'
 daemon = False
 pidfile = '/run/app/gunicorn.pid'


### PR DESCRIPTION
**This doesn't fix the underlying issue of background_task**, but does appear to ensure the gunicorn workers **stay up** when the container runs out of memory. This allows the background task to complete.

Also fixed a mistake in signals.py with filter_text.

```
2023-11-25 23:14:12 s6-rc: info: service s6rc-oneshot-runner: starting
2023-11-25 23:14:12 s6-rc: info: service s6rc-oneshot-runner successfully started
2023-11-25 23:14:12 s6-rc: info: service fix-attrs: starting
2023-11-25 23:14:12 s6-rc: info: service tubesync-init: starting
2023-11-25 23:14:12 s6-rc: info: service fix-attrs successfully started
2023-11-25 23:14:12 s6-rc: info: service legacy-cont-init: starting
2023-11-25 23:14:12 s6-rc: info: service legacy-cont-init successfully started
2023-11-25 23:14:12 groupmod: invalid group ID ''
2023-11-25 23:14:17 TUBESYNC_RESET_DOWNLOAD_DIR=True, Resetting /downloads directory permissions
2023-11-25 23:14:21 Operations to perform:
2023-11-25 23:14:21   Apply all migrations: admin, auth, background_task, contenttypes, sessions, sync
2023-11-25 23:14:21 Running migrations:
2023-11-25 23:14:21   No migrations to apply.
2023-11-25 23:14:21 s6-rc: info: service tubesync-init successfully started
2023-11-25 23:14:21 s6-rc: info: service gunicorn: starting
2023-11-25 23:14:21 s6-rc: info: service gunicorn successfully started
2023-11-25 23:14:21 s6-rc: info: service tubesync-worker: starting
2023-11-25 23:14:21 s6-rc: info: service nginx: starting
2023-11-25 23:14:21 s6-rc: info: service tubesync-worker successfully started
2023-11-25 23:14:21 s6-rc: info: service nginx successfully started
2023-11-25 23:14:21 s6-rc: info: service legacy-services: starting
2023-11-25 23:14:21 s6-rc: info: service legacy-services successfully started
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [316] [INFO] Starting gunicorn 21.2.0
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [316] [INFO] Listening at: http://127.0.0.1:8080 (316)
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [316] [INFO] Using worker: sync
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [358] [INFO] Booting worker with pid: 358
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [359] [INFO] Booting worker with pid: 359
2023-11-25 23:14:22 [2023-11-25 23:14:22 +0000] [366] [INFO] Booting worker with pid: 366
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET / HTTP/1.1" 200 3860 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/styles/tubesync.css HTTP/1.1" 200 34554 "http://localhost:4848/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/fonts/roboto/roboto-bold.woff HTTP/1.1" 200 22284 "http://localhost:4848/static/styles/tubesync.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/fonts/fontawesome/fa-solid-900.woff2 HTTP/1.1" 200 80300 "http://localhost:4848/static/styles/tubesync.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/fonts/fontawesome/fa-regular-400.woff2 HTTP/1.1" 200 13548 "http://localhost:4848/static/styles/tubesync.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/fonts/roboto/roboto-regular.woff HTTP/1.1" 200 22048 "http://localhost:4848/static/styles/tubesync.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/fonts/fontawesome/fa-brands-400.woff2 HTTP/1.1" 200 78460 "http://localhost:4848/static/styles/tubesync.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:26 172.17.0.1 - - [25/Nov/2023:23:14:26 +0000] "GET /static/images/favicon.ico HTTP/1.1" 200 22158 "http://localhost:4848/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:28 172.17.0.1 - - [25/Nov/2023:23:14:28 +0000] "GET /sources HTTP/1.1" 200 2372 "http://localhost:4848/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:36 172.17.0.1 - - [25/Nov/2023:23:14:36 +0000] "GET /source/592c2f4b-3873-4c3b-9373-7c16037b8a9e HTTP/1.1" 200 3471 "http://localhost:4848/sources" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:39 172.17.0.1 - - [25/Nov/2023:23:14:39 +0000] "GET /source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e HTTP/1.1" 200 2341 "http://localhost:4848/source/592c2f4b-3873-4c3b-9373-7c16037b8a9e" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:14:54 2023-11-25 23:14:54,579 [tubesync/INFO] Deleting tasks for media: Arma 3 | Alpha Squad Command [Live Altis Operations I&A]
[...]
2023-11-25 23:15:11 [2023-11-25 23:15:11 +0000] [316] [CRITICAL] WORKER TIMEOUT (pid:358)
2023-11-25 23:15:12 172.17.0.1 - - [25/Nov/2023:23:15:12 +0000] "POST /source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e HTTP/1.1" 502 552 "http://localhost:4848/source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0"
2023-11-25 23:15:12 2023/11/25 23:15:12 [error] 342#342: *1 upstream prematurely closed connection while reading response header from upstream, client: 172.17.0.1, server: _, request: "POST /source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e HTTP/1.1", upstream: "http://127.0.0.1:8080/source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e", host: "localhost:4848", referrer: "http://localhost:4848/source-delete/592c2f4b-3873-4c3b-9373-7c16037b8a9e"
2023-11-25 23:15:12 [2023-11-25 23:15:12 +0000] [316] [ERROR] Worker (pid:358) was sent SIGKILL! Perhaps out of memory?
2023-11-25 23:15:12 [2023-11-25 23:15:12 +0000] [369] [INFO] Booting worker with pid: 369
```